### PR TITLE
Bump to 0.21.0 and add more system dependencies.

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ To manage the continuous integration and simplify feedstock maintenance
 Using the ``conda-forge.yml`` within this repository, it is possible to re-render all of
 this feedstock's supporting files (e.g. the CI configuration files) with ``conda smithy rerender``.
 
+For more information please check the [conda-forge documentation](https://conda-forge.org/docs/).
 
 Terminology
 ===========

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -37,24 +37,24 @@ install:
 
     # Add path, activate `conda` and update conda.
     - cmd: call %CONDA_INSTALL_LOCN%\Scripts\activate.bat
-    - cmd: conda update --yes --quiet conda
+    - cmd: conda.exe update --yes --quiet conda
 
     - cmd: set PYTHONUNBUFFERED=1
 
     # Add our channels.
-    - cmd: conda config --set show_channel_urls true
-    - cmd: conda config --remove channels defaults
-    - cmd: conda config --add channels defaults
-    - cmd: conda config --add channels conda-forge
+    - cmd: conda.exe config --set show_channel_urls true
+    - cmd: conda.exe config --remove channels defaults
+    - cmd: conda.exe config --add channels defaults
+    - cmd: conda.exe config --add channels conda-forge
 
     # Configure the VM.
-    - cmd: conda install -n root --quiet --yes conda-forge-build-setup
+    - cmd: conda.exe install -n root --quiet --yes conda-forge-build-setup
     - cmd: run_conda_forge_build_setup
 
 # Skip .NET project specific build phase.
 build: off
 
 test_script:
-    - conda build recipe --quiet
+    - conda.exe build recipe --quiet
 deploy_script:
     - cmd: upload_or_check_non_existence .\recipe conda-forge --channel=main

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -1,3 +1,2 @@
 #!/bin/bash
-
 $R CMD INSTALL --build .

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,4 @@
-{% set version = '0.19.0' %}
-
+{% set version = '0.21.0' %}
 {% set posix = 'm2-' if win else '' %}
 {% set native = 'm2w64-' if win else '' %}
 
@@ -12,7 +11,7 @@ source:
   url:
     - https://cran.r-project.org/src/contrib/git2r_{{ version }}.tar.gz
     - https://cran.r-project.org/src/contrib/Archive/git2r/git2r_{{ version }}.tar.gz
-  sha256: 380121c31dfb53f3417f9014e841a3b0ff8889f896375295984ea9daec724673
+  sha256: 0480e4c47394ad1724c80982eff3be5ce34168046939340bf22cc1df6b6baf87
 
 build:
   number: 0
@@ -25,14 +24,19 @@ build:
 requirements:
   build:
     - r-base
-    - {{native}}openssl
     - posix                # [win]
     - {{native}}toolchain  # [win]
     - gcc                  # [not win]
+    - libssh2 1.8.*
+    - openssl 1.0.*
+    - zlib 1.2.11
 
   run:
     - r-base
-    - {{native}}openssl
+    - libgcc  # [not win]
+    - libssh2 1.8.*
+    - openssl 1.0.*
+    - zlib 1.2.11
 
 test:
   commands:
@@ -46,9 +50,12 @@ about:
     core methods. Provides access to 'Git' repositories to extract data and running
     some basic 'Git' commands.
   license_family: GPL2
+  license_file: '{{ environ["PREFIX"] }}/lib/R/share/licenses/GPL-2'  # [unix]
+  license_file: '{{ environ["PREFIX"] }}\R\share\licenses\GPL-2'  # [win]
 
 extra:
   recipe-maintainers:
-    - jdblischak
     - johanneskoester
     - bgruening
+    - daler
+    - jdblischak


### PR DESCRIPTION
The [CRAN entry for git2r](https://cran.r-project.org/package=git2r) lists the following system dependencies:


> SystemRequirements: zlib headers and library. OpenSSL headers and library. LibSSH2 (optional on non-Windows) to enable the SSH transport.


The recipe already had openssl, so I added zlib and libssh2. I used the pins listed in [pin_the_slow_way.py](https://github.com/conda-forge/conda-forge.github.io/blob/4c8b3b28ad45e6d46e268acf73de8c0da30de1bc/scripts/pin_the_slow_way.py).

I removed the `{native}` prefix from the dependencies because [libssh2](https://anaconda.org/conda-forge/libssh2/files), [openssl](https://anaconda.org/conda-forge/openssl/files), and [zlib](https://anaconda.org/conda-forge/zlib/files) each list conda packages for win-64. If this fails, I can add the `m2w64-` prefix.